### PR TITLE
Add option to use Strawberry Music Player (fork of Clementine)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,7 @@ Python, `pypresence` and `dbus-python`
 `python main.py`
 
 You can customize the strings by editing the config.py file
+
+### Strawberry
+
+To use this program with Strawberry music player, modify the `APPLICATION` variable in `config.py`.  Set `APPLICATION` to `1`.

--- a/config.py
+++ b/config.py
@@ -11,3 +11,7 @@ NO_ARTIST = "Unknown artist: "
 NO_ARTIST_NOR_ALBUM = "Unknown artist: Unknown album"
 
 STOP_DETAILS = "Idle"
+
+# 0: Clementine Music Player
+# 1: Strawberry Music Player
+APPLICATION = 0

--- a/main.py
+++ b/main.py
@@ -22,7 +22,12 @@ class PresenceUpdate:
 			try:
 				if not self.prop_iface:
 					print("[INFO] Connecting to Clementine")
-					self.player = self.bus.get_object("org.mpris.MediaPlayer2.clementine", '/org/mpris/MediaPlayer2')
+					if APPLICATION == 0:
+						self.player = self.bus.get_object("org.mpris.MediaPlayer2.clementine", '/org/mpris/MediaPlayer2')
+					elif APPLICATION == 1:
+						self.player = self.bus.get_object("org.mpris.MediaPlayer2.strawberry", '/org/mpris/MediaPlayer2')
+					else:
+						raise ValueError(f"Bad APPLICATION value: {APPLICATION}")
 					self.prop_iface = dbus.Interface(self.player, dbus_interface="org.freedesktop.DBus.Properties")
 				print("[INFO] Connecting to Discord")
 				self.client.connect()


### PR DESCRIPTION
Added a variable `APPLICATION` in `config.py` to determine if using [Strawberry](https://github.com/strawberrymusicplayer/strawberry) or Clementine music player.  

Set `APPLICATION` to `1` to use Strawberry.  Set to `0` for Clementine (default).